### PR TITLE
Use "npm ci" instead of "npm i"

### DIFF
--- a/Bundles/SetupFrontend/src/Spryker/Zed/SetupFrontend/SetupFrontendConfig.php
+++ b/Bundles/SetupFrontend/src/Spryker/Zed/SetupFrontend/SetupFrontendConfig.php
@@ -27,7 +27,7 @@ class SetupFrontendConfig extends AbstractBundleConfig
      */
     public function getProjectInstallCommand()
     {
-        return 'npm i --prefer-offline';
+        return 'npm ci --prefer-offline';
     }
 
     /**
@@ -53,7 +53,7 @@ class SetupFrontendConfig extends AbstractBundleConfig
      */
     public function getYvesInstallCommand()
     {
-        return 'npm i --prefer-offline';
+        return 'npm ci --prefer-offline';
     }
 
     /**
@@ -87,7 +87,7 @@ class SetupFrontendConfig extends AbstractBundleConfig
      */
     public function getZedInstallCommand()
     {
-        return 'npm i --prefer-offline';
+        return 'npm ci --prefer-offline';
     }
 
     /**


### PR DESCRIPTION
Since "npm i" is doing changes to the package-lock.json, its best practice to use "npm ci" in automated environments (such as installation scripts).
In my case i have to revert package-lock.json every time i run the install script. Same goes for deployments or ci pipelines.

See:
https://docs.npmjs.com/cli/ci.html
https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable