### PR TITLE
fix setData in SynchronizationDataTransfer in ShoppingListStorage Bun…

### DIFF
--- a/Bundles/ShoppingListStorage/src/Spryker/Zed/ShoppingListStorage/Communication/Plugin/Synchronization/ShoppingListSynchronizationDataBulkPlugin.php
+++ b/Bundles/ShoppingListStorage/src/Spryker/Zed/ShoppingListStorage/Communication/Plugin/Synchronization/ShoppingListSynchronizationDataBulkPlugin.php
@@ -66,7 +66,7 @@ class ShoppingListSynchronizationDataBulkPlugin extends AbstractPlugin implement
 
         foreach ($shoppingListCustomerStorageEntities as $shoppingListCustomerStorageEntity) {
             $synchronizationDataTransfer = new SynchronizationDataTransfer();
-            $synchronizationDataTransfer->setData(json_encode($shoppingListCustomerStorageEntity->getData()));
+            $synchronizationDataTransfer->setData($shoppingListCustomerStorageEntity->getData());
             $synchronizationDataTransfer->setKey($shoppingListCustomerStorageEntity->getKey());
             $synchronizationDataTransfers[] = $synchronizationDataTransfer;
         }

--- a/Bundles/ShoppingListStorage/src/Spryker/Zed/ShoppingListStorage/Communication/Plugin/Synchronization/ShoppingListSynchronizationDataPlugin.php
+++ b/Bundles/ShoppingListStorage/src/Spryker/Zed/ShoppingListStorage/Communication/Plugin/Synchronization/ShoppingListSynchronizationDataPlugin.php
@@ -62,7 +62,7 @@ class ShoppingListSynchronizationDataPlugin extends AbstractPlugin implements Sy
 
         foreach ($shoppingListCustomerStorageEntities as $shoppingListCustomerStorageEntity) {
             $synchronizationDataTransfer = new SynchronizationDataTransfer();
-            $synchronizationDataTransfer->setData(json_encode($shoppingListCustomerStorageEntity->getData()));
+            $synchronizationDataTransfer->setData($shoppingListCustomerStorageEntity->getData());
             $synchronizationDataTransfer->setKey($shoppingListCustomerStorageEntity->getKey());
             $synchronizationDataTransfers[] = $synchronizationDataTransfer;
         }


### PR DESCRIPTION
…dle to avoid error in console (TypeError - Exception: Argument 1 passed to Generated\Shared\Transfer\SynchronizationQueueMessageTransfer::setValue() must be of the type array or null, string given, ... )

- ShoppingListStorage Snychronization Data Plugin
- Patch (Bugfix)
