### PR TITLE
Fix return type annotation in router module

### DIFF
--- a/Bundles/Router/src/Spryker/Yves/Router/RouterDependencyProvider.php
+++ b/Bundles/Router/src/Spryker/Yves/Router/RouterDependencyProvider.php
@@ -94,7 +94,7 @@ class RouterDependencyProvider extends AbstractBundleDependencyProvider
     }
 
     /**
-     * @return \Spryker\Yves\RouterExtension\Dependency\Plugin\RouterPluginInterface[]
+     * @return \Spryker\Yves\RouterExtension\Dependency\Plugin\RouteProviderPluginInterface[]
      */
     protected function getRouteProvider(): array
     {


### PR DESCRIPTION
Just found out the return type annotation of RouterDependencyProvider::getRouteProvider() is wrong, the overriding method in the B2C Demo Shop is correct. The wrong annotation in the core module is very confusing when developing or searching for existing RouteProviderPlugins.