### PR TITLE
Error on Zed Sales when SalesConfigurableBundle is not installed

### DIFF
--- a/Bundles/Sales/src/Spryker/Zed/Sales/Presentation/Detail/boxes/item-group.twig
+++ b/Bundles/Sales/src/Spryker/Zed/Sales/Presentation/Detail/boxes/item-group.twig
@@ -1,5 +1,5 @@
 {% for group in groups | default %}
-    {% if not group.groupItems[0].salesOrderConfiguredBundleItem %}
+    {% if not (group.groupItems[0].salesOrderConfiguredBundleItem is defined and group.groupItems[0].salesOrderConfiguredBundleItem) %}
         {% if group.isBundle %}
             {% include '@Sales/Detail/boxes/order-item.twig' with {
                 orderItem: group.bundleItem,


### PR DESCRIPTION
## 📚 Description

The property `salesOrderConfiguredBundleItem` is added to the `ItemTransfer` in the `SalesConfigurableBundle`, so it should be optional from the `Sales` module in order to make them independent.

## 🔖  Changes

Check if `salesOrderConfiguredBundleItem` property is defined before using it.

## ℹ️  For External PRs 

- Declare the modules and their versions you intend to fix:
```
name     : spryker/sales
descrip. : Sales module
versions : found in latest `11.30`
```
- Specify the proposed release type (patch, minor, major): `patch`


