### PR TITLE
Fix: Throw `InvalidJenkinsConfiguration` with message

### DIFF
--- a/Bundles/SchedulerJenkins/src/Spryker/Zed/SchedulerJenkins/Business/Processor/Configuration/ConfigurationProvider.php
+++ b/Bundles/SchedulerJenkins/src/Spryker/Zed/SchedulerJenkins/Business/Processor/Configuration/ConfigurationProvider.php
@@ -70,7 +70,7 @@ class ConfigurationProvider implements ConfigurationProviderInterface
                 $schedulerJenkinsConfiguration,
             )
         ) {
-            throw new InvalidJenkinsConfiguration('');
+            throw new InvalidJenkinsConfiguration('Base URL has not been configured for Jenkins server.');
         }
 
         return rtrim($schedulerJenkinsConfiguration[SharedSchedulerJenkinsConfig::SCHEDULER_JENKINS_BASE_URL], '/') . '/' . $urlPath;


### PR DESCRIPTION
This pull request

- [x] provides an exception message when throwing an `InvalidJenkinsConfiguration`