### PR TITLE
Check getPaymentMethodKey() for an empty string

### DIFF
--- a/Bundles/Payment/src/Spryker/Zed/Payment/Business/Method/PaymentMethodValidator.php
+++ b/Bundles/Payment/src/Spryker/Zed/Payment/Business/Method/PaymentMethodValidator.php
@@ -82,6 +82,9 @@ class PaymentMethodValidator implements PaymentMethodValidatorInterface
         }
 
         foreach ($quoteTransfer->getPayments() as $paymentTransfer) {
+          if(empty($this->paymentService->getPaymentMethodKey($paymentTransfer)){
+                 continue;
+            }
             $paymentMethodsKeys[] = $this->paymentService->getPaymentMethodKey($paymentTransfer);
         }
 


### PR DESCRIPTION
If getPaymentMethodKey() returns an empty string, it can lead to a Checkout error which is difficult to diagnose. Either throw exception at getPaymentMethodKey if it is not found or check for an empty string here.

<!---

## For External PRs 
Please
- Declare the modules and their versions you intend to fix. 
- Specify the proposed release type (patch, minor, major).

We will then revise. If accepted we make a `.patch` file and finish the release from Core side.


## For Spryker Core Developers
Go to 

- https://release.spryker.com/templates
- (former static template @ https://github.com/spryker/spryker/wiki/Draft-for-PRs in case website is down)

and copy paste your PR template here (as per https://github.com/spryker/spryker/wiki/Pull-Requests guidelines).


NOTE: Replace this block with your actual PR template

-->
