### PR TITLE
Fix default sorting column for products in merchant portal

### DIFF
--- a/Bundles/ProductMerchantPortalGui/src/Spryker/Zed/ProductMerchantPortalGui/Persistence/ProductMerchantPortalGuiRepository.php
+++ b/Bundles/ProductMerchantPortalGui/src/Spryker/Zed/ProductMerchantPortalGui/Persistence/ProductMerchantPortalGuiRepository.php
@@ -379,8 +379,14 @@ class ProductMerchantPortalGuiRepository extends AbstractRepository implements P
         SpyMerchantProductAbstractQuery $merchantProductAbstractQuery,
         MerchantProductTableCriteriaTransfer $merchantProductTableCriteriaTransfer
     ): SpyMerchantProductAbstractQuery {
-        $orderColumn = $merchantProductTableCriteriaTransfer->getOrderBy() ?? static::COL_KEY_PRODUCT_ABSTRACT_SKU;
         $orderDirection = $merchantProductTableCriteriaTransfer->getOrderDirection() ?? Criteria::DESC;
+        if ($merchantProductTableCriteriaTransfer->getOrderBy() === null) {
+            $merchantProductAbstractQuery->orderByIdMerchantProductAbstract($orderDirection);
+
+            return $merchantProductAbstractQuery;
+        }
+
+        $orderColumn = $merchantProductTableCriteriaTransfer->getOrderBy();
 
         if (!$orderColumn || !$orderDirection) {
             return $merchantProductAbstractQuery;


### PR DESCRIPTION
## Description:
By default in the merchant portal product page, we filter by SKU length, it takes time for the database to sort by calculated value, and it's doesn't have any business value, usually users want to see created products at the top, but with this sorting, they will be somewhere.

## Modules:
spryker/product-merchant-portal-gui 4.2.0 patch
Adjusted default sorting

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
