### PR TITLE
Add cache for the ACL entity rule check

### DIFF
--- a/Bundles/Acl/src/Spryker/Zed/Acl/Business/Model/Rule.php
+++ b/Bundles/Acl/src/Spryker/Zed/Acl/Business/Model/Rule.php
@@ -64,6 +64,11 @@ class Rule implements RuleInterface
     protected array $aclAccessCheckerStrategyPlugins;
 
     /**
+     * @var array<mixed>
+     */
+    protected static array $cache = [];
+
+    /**
      * @param \Spryker\Zed\Acl\Business\Model\GroupInterface $group
      * @param \Spryker\Zed\Acl\Persistence\AclQueryContainerInterface $queryContainer
      * @param \Spryker\Zed\Acl\Dependency\Facade\AclToUserInterface $facadeUser
@@ -308,6 +313,15 @@ class Rule implements RuleInterface
         }
     }
 
+    public function isAllowed(UserTransfer $userTransfer, $bundle, $controller, $action): bool
+    {
+        if (!isset(static::$cache[$userTransfer->getIdUser()][$bundle][$controller][$action])) {
+            static::$cache[$userTransfer->getIdUser()][$bundle][$controller][$action] = $this->executeIsAllowed($userTransfer, $bundle, $controller, $action);
+        }
+
+        return static::$cache[$userTransfer->getIdUser()][$bundle][$controller][$action];
+    }
+
     /**
      * @param \Generated\Shared\Transfer\UserTransfer $userTransfer
      * @param string $bundle
@@ -316,7 +330,7 @@ class Rule implements RuleInterface
      *
      * @return bool
      */
-    public function isAllowed(UserTransfer $userTransfer, $bundle, $controller, $action)
+    protected function executeIsAllowed(UserTransfer $userTransfer, $bundle, $controller, $action)
     {
         if ($this->userFacade->isSystemUser($userTransfer)) {
             $this->registerSystemUserRules($userTransfer);

--- a/Bundles/AclEntity/src/Spryker/Zed/AclEntity/Business/Reader/AclEntityMetadataConfigReader.php
+++ b/Bundles/AclEntity/src/Spryker/Zed/AclEntity/Business/Reader/AclEntityMetadataConfigReader.php
@@ -31,6 +31,11 @@ class AclEntityMetadataConfigReader implements AclEntityMetadataConfigReaderInte
     protected $aclEntityMetadataConfigFilter;
 
     /**
+     * @var array<\Generated\Shared\Transfer\AclEntityMetadataConfigTransfer>
+     */
+    protected static array $cache = [];
+
+    /**
      * @param array<\Spryker\Zed\AclEntityExtension\Dependency\Plugin\AclEntityMetadataConfigExpanderPluginInterface> $aclEntityMetadataCollectionExpandPlugins
      * @param \Spryker\Zed\AclEntity\Business\Validator\AclEntityMetadataConfigValidatorInterface $aclEntityMetadataConfigValidator
      * @param \Spryker\Zed\AclEntity\Business\Filter\AclEntityMetadataConfigFilterInterface $aclEntityMetadataConfigFilter
@@ -52,6 +57,24 @@ class AclEntityMetadataConfigReader implements AclEntityMetadataConfigReaderInte
      * @return \Generated\Shared\Transfer\AclEntityMetadataConfigTransfer
      */
     public function getAclEntityMetadataConfig(
+        bool $runValidation = true,
+        ?AclEntityMetadataConfigRequestTransfer $aclEntityMetadataConfigRequestTransfer = null
+    ): AclEntityMetadataConfigTransfer {
+        $modelName = $aclEntityMetadataConfigRequestTransfer?->getModelName() ?? '';
+        if (!isset(static::$cache[$runValidation][$modelName])) {
+            static::$cache[$runValidation][$modelName] = $this->executeGetAclEntityMetadataConfig($runValidation, $aclEntityMetadataConfigRequestTransfer);
+        }
+
+        return static::$cache[$runValidation][$modelName];
+    }
+
+    /**
+     * @param bool $runValidation
+     * @param \Generated\Shared\Transfer\AclEntityMetadataConfigRequestTransfer|null $aclEntityMetadataConfigRequestTransfer
+     *
+     * @return \Generated\Shared\Transfer\AclEntityMetadataConfigTransfer
+     */
+    protected function executeGetAclEntityMetadataConfig(
         bool $runValidation = true,
         ?AclEntityMetadataConfigRequestTransfer $aclEntityMetadataConfigRequestTransfer = null
     ): AclEntityMetadataConfigTransfer {

--- a/Bundles/AclEntity/src/Spryker/Zed/AclEntity/Persistence/Propel/Provider/AclEntityRuleProvider.php
+++ b/Bundles/AclEntity/src/Spryker/Zed/AclEntity/Persistence/Propel/Provider/AclEntityRuleProvider.php
@@ -23,6 +23,11 @@ class AclEntityRuleProvider implements AclEntityRuleProviderInterface
     protected $aclEntityRepository;
 
     /**
+     * @var AclEntityRuleCollectionTransfer|null
+     */
+    protected static ?AclEntityRuleCollectionTransfer $aclEntityRuleCollectionTransfer = null;
+
+    /**
      * @param \Spryker\Zed\AclEntity\Persistence\Propel\Provider\AclRoleProviderInterface $aclRoleProvider
      * @param \Spryker\Zed\AclEntity\Persistence\AclEntityRepositoryInterface $aclEntityRepository
      */
@@ -38,6 +43,18 @@ class AclEntityRuleProvider implements AclEntityRuleProviderInterface
      * @return \Generated\Shared\Transfer\AclEntityRuleCollectionTransfer
      */
     public function getCurrentUserAclEntityRules(): AclEntityRuleCollectionTransfer
+    {
+        if (static::$aclEntityRuleCollectionTransfer === null) {
+            static::$aclEntityRuleCollectionTransfer = $this->executeGetCurrentUserAclEntityRules();
+        }
+
+        return static::$aclEntityRuleCollectionTransfer;
+    }
+
+    /**
+     * @return \Generated\Shared\Transfer\AclEntityRuleCollectionTransfer
+     */
+    public function executeGetCurrentUserAclEntityRules(): AclEntityRuleCollectionTransfer
     {
         return $this->aclEntityRepository->getAclEntityRulesByRoles(
             $this->aclRoleProvider->getCurrentUserAclRoles(),


### PR DESCRIPTION

## Description
The problem for this fix is described in the FRW-2464 point 2

In the merchant portal, we create rules on the fly for each entity each time
If you load 25 products, and join them with prices, stores, translations, etc. you can easily ~1.5 million checks

It would be strange if rules were changed in the middle of execution, and there is no way to change them on the fly.
But we spend 50%-80% of execution time for these checks

This fix solved the issue.
Should be patch

**Example**
![image](https://github.com/user-attachments/assets/88f3577b-bd56-4300-9af6-f140e4b7989d)
