### PR TITLE
Zed gateway twig related performance fix

### DIFF
--- a/Bundles/Twig/src/Spryker/Zed/Twig/Communication/Plugin/Application/ZedGatewayTwigApplicationPlugin.php
+++ b/Bundles/Twig/src/Spryker/Zed/Twig/Communication/Plugin/Application/ZedGatewayTwigApplicationPlugin.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Twig\Communication\Plugin\Application;
+
+
+use Spryker\Service\Container\ContainerInterface;
+use Twig\Environment;
+
+class ZedGatewayTwigApplicationPlugin extends TwigApplicationPlugin
+{
+    protected const PLUGIN_TO_IGNORE = 'Spryker\Zed\ZedNavigation\Communication\Plugin\Twig\ZedNavigationTwigPlugin';
+
+    /**
+     * @param \Twig\Environment $twig
+     * @param \Spryker\Service\Container\ContainerInterface $container
+     *
+     * @return \Twig\Environment
+     */
+    protected function extendTwig(Environment $twig, ContainerInterface $container): Environment
+    {
+        $twigPlugins = $this->getFactory()->getTwigPlugins();
+        foreach ($twigPlugins as $twigPlugin) {
+            if ($twigPlugin::class === self::PLUGIN_TO_IGNORE) {
+                continue;
+            }
+
+            $twig = $twigPlugin->extend($twig, $container);
+        }
+
+        return $twig;
+    }
+}

--- a/Bundles/Twig/src/Spryker/Zed/Twig/Communication/Plugin/Application/ZedGatewayTwigApplicationPlugin.php
+++ b/Bundles/Twig/src/Spryker/Zed/Twig/Communication/Plugin/Application/ZedGatewayTwigApplicationPlugin.php
@@ -11,6 +11,10 @@ namespace Spryker\Zed\Twig\Communication\Plugin\Application;
 use Spryker\Service\Container\ContainerInterface;
 use Twig\Environment;
 
+/**
+* This plugin will deactivate Navigation from Twig plugin stack.
+* It's handy for Zed applications that don't need to draw a default Zed UI navigation.
+*/
 class ZedGatewayTwigApplicationPlugin extends TwigApplicationPlugin
 {
     protected const PLUGIN_TO_IGNORE = 'Spryker\Zed\ZedNavigation\Communication\Plugin\Twig\ZedNavigationTwigPlugin';


### PR DESCRIPTION
## Description:

Related to FRW-2464 point 4

For now, we have one twig-related plugin for ZED and for the Gateway.
Each time when you render something in the gateway (like email sending) we also render full zed navigation.
More navigation systems have in ZED - slower emails that customers trigger from YVES.

Sometimes it takes up to 80% execution time.

This new plugin `ZedGatewayTwigApplicationPlugin` should be injected instead of `TwigApplicationPlugin` in the `src/Pyz/Zed/Application/ApplicationDependencyProvider::getBackendGatewayApplicationPlugins()`

**Example:**
![image](https://github.com/user-attachments/assets/98b00f49-a1a9-44dc-b995-ff28f676e5dd)
