### PR TITLE
Enable propel error loging

### DIFF
--- a/Bundles/Propel/src/Spryker/Zed/Propel/Communication/PropelCommunicationFactory.php
+++ b/Bundles/Propel/src/Spryker/Zed/Propel/Communication/PropelCommunicationFactory.php
@@ -9,6 +9,7 @@ namespace Spryker\Zed\Propel\Communication;
 
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use Spryker\Shared\Log\LoggerFactory;
 use Spryker\Zed\Kernel\Communication\AbstractCommunicationFactory;
 use Spryker\Zed\Propel\Communication\Command\Config\PropelCommandConfigurator;
 use Spryker\Zed\Propel\Communication\Command\Config\PropelCommandConfiguratorInterface;
@@ -32,32 +33,13 @@ use Symfony\Component\Console\Command\Command;
  */
 class PropelCommunicationFactory extends AbstractCommunicationFactory
 {
-    /**
-     * @var string
-     */
-    public const LOGGER_NAME = 'defaultLogger';
 
     /**
      * @return array<\Monolog\Logger>
      */
     public function createLogger()
     {
-        $defaultLogger = new Logger(static::LOGGER_NAME);
-        $defaultLogger->pushHandler(
-            $this->createStreamHandler(),
-        );
-
-        return [$defaultLogger];
-    }
-
-    /**
-     * @return \Monolog\Handler\StreamHandler
-     */
-    protected function createStreamHandler()
-    {
-        return new StreamHandler(
-            $this->getConfig()->getLogPath(),
-        );
+        return [LoggerFactory::getInstance()];
     }
 
     /**


### PR DESCRIPTION
Internal task - SUPESC-944

Current logger lose the internal errors in cloud
Shared longer have a list of benefits:
1. The list of the handlers should be included once (like monitoring handlers)
2. Config for the logger (like log level) should be created once
3. This longer working good in the cloud already. 
