### PR TITLE
Show data import errors

### DIFF
--- a/Bundles/DataImport/src/Spryker/Zed/DataImport/Communication/Console/DataImportConsole.php
+++ b/Bundles/DataImport/src/Spryker/Zed/DataImport/Communication/Console/DataImportConsole.php
@@ -379,6 +379,10 @@ class DataImportConsole extends Console
             $dataImporterReport->getImportTime(),
             $this->getImportStatusByDataImportReportStatus($dataImporterReport),
         ));
+
+        foreach ($dataImporterReport->getMessages() as $dataImporterReportMessageTransfer) {
+            $this->warning($dataImporterReportMessageTransfer->getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
Internal task: SUPESC-945
If data import failed, it never shows the next information:

- It doesn't say which data import step has failed.
- Which line/method in the step.

Because of this problem, even a small data problem requires deep debugging and a huge time wasting.
More interestingly, we already have implemented methods that gather needed information, we just do not show it.
So, we just need to show it